### PR TITLE
Wire up pytest, CI, and light refactoring

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,40 @@
+name: Tests and lints
+
+on:
+  push:
+    branches:
+      - "master"
+
+  pull_request:
+    branches:
+      - "master"
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone oresat-solar-simulator-software repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Install dependencies
+        id: dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install . --group dev
+
+      - name: Lint with Ruff
+        if: always() && steps.dependencies.conclusion == 'success'
+        run: ruff check
+
+      - name: Check format with Ruff
+        if: always() && steps.dependencies.conclusion == 'success'
+        run: ruff format --check --diff
+
+      - name: Test with pytest
+        if: always() && steps.dependencies.conclusion == 'success'
+        run: pytest tests

--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ and follow the instructions under "Learn how to install CircuitPython on this bo
     make write
     ```
 
+## Testing
+
+This project uses [pytest](https://docs.pytest.org/en/stable/). To run the test suite, simply run:
+
+```sh
+pytest
+```
+
 ## Acknowledgements
 
 The original work for this was done as an MCECS Capstone Project from January to June of 2023 by Bendjy Faurestal,

--- a/docs/solar_simulator_module.md
+++ b/docs/solar_simulator_module.md
@@ -36,10 +36,10 @@ sim = ss.SolarSimulator()
 # Read and print temperature values every second
 while True:
     temps = sim.check_thermals()
-    print('~'*21)
+    print('~' * 21)
     for i, temp in zip(range(3), temps):
         print(f"Thermistor[{i}]: {temp:.2f}C")
-    
+
     time.sleep(1)
 ```
 
@@ -78,7 +78,7 @@ while True:
     time.sleep(1)
 
     # Set all of the lights to half brightness
-    sim.set_leds(65535//2, 65535//2, 65535//2, 65535//2)
+    sim.set_leds(65535 // 2, 65535 // 2, 65535 // 2, 65535 // 2)
     time.sleep(1)
 
     # Turn all of the lights off (quick method)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
+pythonpath = ["src", "src/solar_simulator"]
 testpaths = ["tests"]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,13 @@ ignore = [
     "D203",     # one-blank-line-before-class
     "D213",     # multi-line-summary-second-line
     "FIX",      # flake8-fixme
+    "T201",     # print statements are acceptable
+    "TC001",    # typing-only-first-party-import
     "TD001",    # invalid-todo-tag
     "TD002",    # missing-todo-author
     "TD003",    # missing-todo-link
     "TD004",    # missing-todo-colon
+    "TID252",   # relative imports are fine
     "EM101",    # raw-string-in-exception
     "EM102",    # f-string-in-exception
     "D413",     # blank-line-after-last-section
@@ -54,8 +57,6 @@ ignore = [
     "PLR2004",  # magic value used in comparison
     "PLR0911",  # too many return statements
     "CPY001",   # missing-copyright-notice
-    "TC001",    # typing-only-first-party-import
-    "T201",     # print statements are acceptable
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
-pythonpath = ["src", "src/solar_simulator"]
 testpaths = ["tests"]
 
 [tool.ruff]

--- a/src/solar_simulator/lib/app.py
+++ b/src/solar_simulator/lib/app.py
@@ -14,27 +14,35 @@ class SolarSimulatorApp:
         """Initialize Solar Simulator App."""
         self.sim = sim
 
-
     def run(self) -> None:
         """Run the Solar Simulator App."""
         self.mode_selection()
 
-
     def setup(self) -> None:
         """Set up the cli menu options."""
         default_settings_summary = (
-                "\nDefault settings are:\n"
-                "  - Thermal Monitoring: " + ("Enabled" if self.sim.enable_therm_monitoring else "Disabled") + "\n" +  # noqa: E501
-                "  - LED Shutdown Temperature: " + str(self.sim.therm_led_shutdown) + "°C\n" +
-                "  - Heatsink Shutdown Temperature: " + str(self.sim.therm_heatsink_shutdown) + "°C\n" +  # noqa: E501
-                "  - Cell Shutdown Temperature: " + str(self.sim.therm_cell_shutdown) + "°C\n" +
-                "  - Resume Operation Temperature: " + str(self.sim.therm_resume_temp) + "°C\n"
+            "\nDefault settings are:\n"
+            "  - Thermal Monitoring: "
+            + ("Enabled" if self.sim.enable_therm_monitoring else "Disabled")
+            + "\n"
+            + "  - LED Shutdown Temperature: "
+            + str(self.sim.therm_led_shutdown)
+            + "°C\n"
+            + "  - Heatsink Shutdown Temperature: "
+            + str(self.sim.therm_heatsink_shutdown)
+            + "°C\n"
+            + "  - Cell Shutdown Temperature: "
+            + str(self.sim.therm_cell_shutdown)
+            + "°C\n"
+            + "  - Resume Operation Temperature: "
+            + str(self.sim.therm_resume_temp)
+            + "°C\n"
         )
 
         change_settings = input_with_default(
             f"Would you like to change the default settings? (yes/no, default is no): {default_settings_summary}",  # noqa: E501
             default_value="no",
-            valid_values=["yes", "no"]
+            valid_values=["yes", "no"],
         )
 
         if change_settings == "yes":
@@ -42,7 +50,7 @@ class SolarSimulatorApp:
             enable_therm_monitoring_input = input_with_default(
                 "Would you like to enable thermal monitoring? (yes/no, default is yes): ",
                 default_value="yes",
-                valid_values=["yes", "no"]
+                valid_values=["yes", "no"],
             )
             self.sim.enable_therm_monitoring = enable_therm_monitoring_input == "yes"
 
@@ -50,22 +58,22 @@ class SolarSimulatorApp:
             self.sim.therm_led_shutdown = input_with_default(
                 "Set LED shutdown temperature (default is 100°C): ",
                 default_value=100,
-                value_type=int
+                value_type=int,
             )
             self.sim.therm_heatsink_shutdown = input_with_default(
                 "Set Heatsink shutdown temperature (default is 60°C): ",
                 default_value=60,
-                value_type=int
+                value_type=int,
             )
             self.sim.therm_cell_shutdown = input_with_default(
                 "Set Cell shutdown temperature (default is 80°C): ",
                 default_value=80,
-                value_type=int
+                value_type=int,
             )
             self.sim.therm_resume_temp = input_with_default(
                 "Set temperature to resume operation (default is 45°C): ",
                 default_value=45,
-                value_type=int
+                value_type=int,
             )
         else:
             print("Using default settings. No changes were made.")
@@ -81,7 +89,7 @@ class SolarSimulatorApp:
         while True:
             mode = input("Your mode (input 1, 2, 3 or 4 if you need change default): ")
 
-            if mode in ["1", "2", "3","4"]:
+            if mode in ["1", "2", "3", "4"]:
                 mode = int(mode)
             else:
                 print("Invalid input. Please enter 1, 2, or 3.")

--- a/src/solar_simulator/lib/modes/auto_mode.py
+++ b/src/solar_simulator/lib/modes/auto_mode.py
@@ -2,15 +2,15 @@
 
 import time
 
-from lib.utils import (
+from ulab import numpy as np
+
+from solar_simulator.lib.solar_simulator import SolarSimulator as Sim
+from solar_simulator.lib.utils import (
     calculate_light_intensity,
     check_for_interrupt,
     check_temperature,
     display_status,
 )
-from ulab import numpy as np
-
-from solar_simulator import SolarSimulator as Sim
 
 
 class AutoMode:

--- a/src/solar_simulator/lib/modes/auto_mode.py
+++ b/src/solar_simulator/lib/modes/auto_mode.py
@@ -4,8 +4,8 @@ import time
 
 from ulab import numpy as np
 
-from solar_simulator.lib.solar_simulator import SolarSimulator as Sim
-from solar_simulator.lib.utils import (
+from ..solar_simulator import SolarSimulator as Sim
+from ..utils import (
     calculate_light_intensity,
     check_for_interrupt,
     check_temperature,

--- a/src/solar_simulator/lib/modes/auto_mode.py
+++ b/src/solar_simulator/lib/modes/auto_mode.py
@@ -21,7 +21,6 @@ class AutoMode:
         self.sim = sim
         self.peak = 0.5
 
-
     def run(self) -> None:
         """Run auto mode loop."""
         print("Entering Auto Mode")
@@ -43,10 +42,10 @@ class AutoMode:
             return
 
         # Generate a sine wave pattern
-        wave = 0.5 * (1 - np.cos(np.linspace(0, 2*np.pi, 101)))
+        wave = 0.5 * (1 - np.cos(np.linspace(0, 2 * np.pi, 101)))
         level = 0  # Initialize wave level index
-        loop_time = period/len(wave) # average loop repetition time
-                                     #  to get correct period
+        loop_time = period / len(wave)  # average loop repetition time
+        #  to get correct period
 
         try:
             loop_start = time.monotonic()
@@ -71,7 +70,7 @@ class AutoMode:
                         'v': violet,
                         'w': white,
                         'c': cyan,
-                        'h': halogen
+                        'h': halogen,
                     }
                     # Update level index for sine wave
                     level = (level + 1) % len(wave)

--- a/src/solar_simulator/lib/modes/auto_mode.py
+++ b/src/solar_simulator/lib/modes/auto_mode.py
@@ -44,8 +44,7 @@ class AutoMode:
         # Generate a sine wave pattern
         wave = 0.5 * (1 - np.cos(np.linspace(0, 2 * np.pi, 101)))
         level = 0  # Initialize wave level index
-        loop_time = period / len(wave)  # average loop repetition time
-        #  to get correct period
+        loop_time = period / len(wave)  # average loop repetition time to get correct period
 
         try:
             loop_start = time.monotonic()

--- a/src/solar_simulator/lib/modes/basilisk_mode.py
+++ b/src/solar_simulator/lib/modes/basilisk_mode.py
@@ -5,9 +5,9 @@ import time
 
 import supervisor
 
-from solar_simulator.lib.modes.manual_mode import check_temperature, display_status
-from solar_simulator.lib.solar_simulator import SolarSimulator as Sim
-from solar_simulator.lib.utils import calculate_light_intensity
+from ..solar_simulator import SolarSimulator as Sim
+from ..utils import calculate_light_intensity
+from .manual_mode import check_temperature, display_status
 
 
 class BasiliskMode:

--- a/src/solar_simulator/lib/modes/basilisk_mode.py
+++ b/src/solar_simulator/lib/modes/basilisk_mode.py
@@ -17,7 +17,6 @@ class BasiliskMode:
         """Initialize basilisk mode."""
         self.sim = sim
 
-
     def run(self) -> None:
         """Run basilisk mode loop."""
         print("Entering Basilisk Mode, wait for data input")
@@ -46,7 +45,7 @@ class BasiliskMode:
                                 'v': violet,
                                 'w': white,
                                 'c': cyan,
-                                'h': halogen
+                                'h': halogen,
                             }
 
                             print(f"BasiliskMode: Intensity={intensity}", end="\n")

--- a/src/solar_simulator/lib/modes/basilisk_mode.py
+++ b/src/solar_simulator/lib/modes/basilisk_mode.py
@@ -4,10 +4,10 @@ import sys
 import time
 
 import supervisor
-from lib.modes.manual_mode import check_temperature, display_status
-from lib.utils import calculate_light_intensity
 
-from solar_simulator import SolarSimulator as Sim
+from solar_simulator.lib.modes.manual_mode import check_temperature, display_status
+from solar_simulator.lib.solar_simulator import SolarSimulator as Sim
+from solar_simulator.lib.utils import calculate_light_intensity
 
 
 class BasiliskMode:

--- a/src/solar_simulator/lib/modes/manual_mode.py
+++ b/src/solar_simulator/lib/modes/manual_mode.py
@@ -4,14 +4,14 @@ import sys
 import time
 
 import supervisor
-from lib.utils import (
+
+from solar_simulator.lib.solar_simulator import SolarSimulator as Sim
+from solar_simulator.lib.utils import (
     calculate_light_intensity,
     check_for_interrupt,
     check_temperature,
     display_status,
 )
-
-from solar_simulator import SolarSimulator as Sim
 
 
 class ManualMode:

--- a/src/solar_simulator/lib/modes/manual_mode.py
+++ b/src/solar_simulator/lib/modes/manual_mode.py
@@ -21,7 +21,6 @@ class ManualMode:
         """Initialize manual mode."""
         self.sim = sim
 
-
     def run(self) -> None:
         """Run manual mode loop."""
         print("Entering Manual Mode")
@@ -49,7 +48,6 @@ class ManualMode:
             self.measurement_mode()
         elif choice == '5':
             self.fine_tuning_adjustment()
-
 
     def fixed_preset_mode(self) -> None:
         """Set Fixed Preset Mode."""
@@ -82,12 +80,7 @@ class ManualMode:
             halogen = int(intensity_values["Halogen"] * 655)
 
             self.sim.set_leds(v=violet, w=white, c=cyan, h=halogen)
-            self.sim.current_light_settings = {
-                'v': violet,
-                'w': white,
-                'c': cyan,
-                'h': halogen
-            }
+            self.sim.current_light_settings = {'v': violet, 'w': white, 'c': cyan, 'h': halogen}
 
             print(f"\nCurrent intensity: {intensity_input:.2f}")
             print("Press 'Enter' to reset your LEDs...")
@@ -115,7 +108,6 @@ class ManualMode:
                     input_line += c
                 time.sleep(1)
 
-
     def manual_light_adjustment(self) -> None:  # noqa: PLR0915, C901
         """Manual Light Source Adjustment."""
         while True:
@@ -140,8 +132,12 @@ class ManualMode:
                 cyan_percent = float(cyan_input)
                 halogen_percent = float(halogen_input)
 
-                if not (0 <= violet_percent <= 100 and 0 <= white_percent <= 100 and
-                        0 <= cyan_percent <= 100 and 0 <= halogen_percent <= 100):
+                if not (
+                    0 <= violet_percent <= 100
+                    and 0 <= white_percent <= 100
+                    and 0 <= cyan_percent <= 100
+                    and 0 <= halogen_percent <= 100
+                ):
                     print("Invalid input. Please enter values between 0 and 100.")
                     continue
 
@@ -152,12 +148,7 @@ class ManualMode:
 
                 self.sim.set_leds(v=violet, w=white, c=cyan, h=halogen)
                 print("Lights set to the specified intensities.")
-                self.sim.current_light_settings = {
-                    'v': violet,
-                    'w': white,
-                    'c': cyan,
-                    'h': halogen
-                }
+                self.sim.current_light_settings = {'v': violet, 'w': white, 'c': cyan, 'h': halogen}
                 input_line = ""
                 print("Press 'Enter' to input new values, or 'exit' to return to the main menu.")
 

--- a/src/solar_simulator/lib/modes/manual_mode.py
+++ b/src/solar_simulator/lib/modes/manual_mode.py
@@ -5,8 +5,8 @@ import time
 
 import supervisor
 
-from solar_simulator.lib.solar_simulator import SolarSimulator as Sim
-from solar_simulator.lib.utils import (
+from ..solar_simulator import SolarSimulator as Sim
+from ..utils import (
     calculate_light_intensity,
     check_for_interrupt,
     check_temperature,

--- a/src/solar_simulator/lib/solar_simulator.py
+++ b/src/solar_simulator/lib/solar_simulator.py
@@ -93,7 +93,7 @@ class SolarSimulator:
 
 
     def _read_thermistors(self) -> list:
-        """Read all of the thermistors and returns a list of lists of data for each channel.
+        """Read all of the thermistors and return a nested list of data for each channel.
 
         Example Output:
         [[CHAN0 binary data, voltage, celsius temp],
@@ -104,23 +104,22 @@ class SolarSimulator:
         for i in range(3):
             chan = AnalogIn(self.ads, i)
             therm_values.append(
-                [chan.value >> 4, chan.voltage, calc_temp(chan.voltage)]
+                [chan.value >> 4, chan.voltage, self._calc_temp(chan.voltage)]
             )
 
         return therm_values
 
 
-def calc_temp(v_adc: float, vcc: float = 3.3, r_fixed: float = 10000.0) -> float | None:
-    """Calculate the temperature."""
-    # Compute thermistor resistance
-    r_therm = r_fixed * v_adc / (vcc - v_adc)
-    # Compute temperature using beta equation
-    beta = 3977   # From datasheet (B25/85)
-    t0 = 298.15   # Reference temperature in Kelvin (25°C)
-    r0 = 10000.0  # Resistance at t0 (25°C)
+    @staticmethod
+    def _calc_temp(v_adc: float, vcc: float = 3.3, r_fixed: float = 10000.0) -> float:
+        """Given thermistor resistance, calculuate and return temperature (in Celsius)."""
+        # Thermistor resistance
+        r_therm = r_fixed * v_adc / (vcc - v_adc)
 
-    try:
+        # Compute temperature (beta equation)
+        beta = 3977   # From datasheet (B25/85)
+        t0 = 298.15   # Reference temperature in Kelvin (25°C)
+        r0 = 10000.0  # Resistance at t0 (25°C)
         temp_k = 1.0 / ((math.log(r_therm / r0) / beta) + (1.0 / t0))
+
         return temp_k - 273.15
-    except ValueError:
-        return None

--- a/src/solar_simulator/lib/solar_simulator.py
+++ b/src/solar_simulator/lib/solar_simulator.py
@@ -29,24 +29,15 @@ class SolarSimulator:
         self.ads = ads.ADS1015(self.i2c)
         self.mcp = mcp.MCP4728(self.i2c)
         self.hal = PWMOut(
-            board.GP28,
-            frequency=self.PWM_FREQ,
-            duty_cycle=0,
-            variable_frequency=True
+            board.GP28, frequency=self.PWM_FREQ, duty_cycle=0, variable_frequency=True
         )
         self.therm_safe = True
-        self.current_light_settings = {
-            'v': 0,
-            'w': 0,
-            'c': 0,
-            'h': 0
-        }
+        self.current_light_settings = {'v': 0, 'w': 0, 'c': 0, 'h': 0}
         self.enable_therm_monitoring = True
         self.therm_led_shutdown = 100
         self.therm_heatsink_shutdown = 60
         self.therm_cell_shutdown = 80
         self.therm_resume_temp = 45
-
 
     def set_leds(self, v: int = 0, w: int = 0, c: int = 0, h: int = 0) -> None:
         """Set the light brightness levels and record the light configuration.
@@ -58,13 +49,7 @@ class SolarSimulator:
         self.mcp.channel_b.value = w
         self.mcp.channel_c.value = c
         self.hal.duty_cycle = h
-        self.current_light_settings = {
-            'v': v,
-            'w': w,
-            'c': c,
-            'h': h
-        }
-
+        self.current_light_settings = {'v': v, 'w': w, 'c': c, 'h': h}
 
     def check_thermals(self) -> list:
         """Return a list of thermal values per thermistor channel in Celsius.
@@ -82,7 +67,6 @@ class SolarSimulator:
 
         return thermals
 
-
     def _port_scan(self) -> list:
         """Print all available I2C devices."""
         self.i2c.try_lock()
@@ -90,7 +74,6 @@ class SolarSimulator:
         self.i2c.unlock()
 
         return [hex(i) for i in found]
-
 
     def _read_thermistors(self) -> list:
         """Read all of the thermistors and return a nested list of data for each channel.
@@ -103,12 +86,9 @@ class SolarSimulator:
         therm_values = []
         for i in range(3):
             chan = AnalogIn(self.ads, i)
-            therm_values.append(
-                [chan.value >> 4, chan.voltage, self._calc_temp(chan.voltage)]
-            )
+            therm_values.append([chan.value >> 4, chan.voltage, self._calc_temp(chan.voltage)])
 
         return therm_values
-
 
     @staticmethod
     def _calc_temp(v_adc: float, vcc: float = 3.3, r_fixed: float = 10000.0) -> float:
@@ -117,8 +97,8 @@ class SolarSimulator:
         r_therm = r_fixed * v_adc / (vcc - v_adc)
 
         # Compute temperature (beta equation)
-        beta = 3977   # From datasheet (B25/85)
-        t0 = 298.15   # Reference temperature in Kelvin (25°C)
+        beta = 3977  # From datasheet (B25/85)
+        t0 = 298.15  # Reference temperature in Kelvin (25°C)
         r0 = 10000.0  # Resistance at t0 (25°C)
         temp_k = 1.0 / ((math.log(r_therm / r0) / beta) + (1.0 / t0))
 

--- a/src/solar_simulator/lib/utils.py
+++ b/src/solar_simulator/lib/utils.py
@@ -39,7 +39,9 @@ def display_status(sim: Sim) -> None:
 
         if thermals:
             led_temp, heatsink_temp, cell_temp = thermals
-            temp_info = f"LED: {led_temp:.1f}°C, Heatsink: {heatsink_temp:.1f}°C, Cell: {cell_temp:.1f}°C"  # noqa: E501
+            temp_info = (
+                f"LED: {led_temp:.1f}°C, Heatsink: {heatsink_temp:.1f}°C, Cell: {cell_temp:.1f}°C"
+            )
         else:
             temp_info = "Cannot read temperature data"
     except Exception:  # noqa: BLE001
@@ -123,7 +125,7 @@ def check_temperature(sim: Sim) -> bool:
                 v=previous_light_settings['v'],
                 w=previous_light_settings['w'],
                 c=previous_light_settings['c'],
-                h=previous_light_settings['h']
+                h=previous_light_settings['h'],
             )
         return True
 
@@ -135,7 +137,7 @@ def check_for_interrupt() -> None:
     if supervisor.runtime.serial_bytes_available:
         input_char = sys.stdin.read(1)
 
-        if input_char == '\x03': #Ctrl-C (ASCII 3)
+        if input_char == '\x03':  # Ctrl-C (ASCII 3)
             print("\nCtrl-C detected. Turning off LEDs...")
             Sim.set_leds(0, 0, 0, 0)
             raise KeyboardInterrupt

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""The solar simulator test suite module."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+"""Pytest configuration."""
+
+import sys
+from unittest.mock import MagicMock
+
+CIRCUITPYTHON_MODULES = {
+    "adafruit_ads1x15",
+    "adafruit_ads1x15.ads1015",
+    "adafruit_ads1x15.analog_in",
+    "adafruit_mcp4728",
+    "board",
+    "busio",
+    "micropython",
+    "pdb",
+    "pwmio",
+    "supervisor",
+    "ulab",
+}
+
+
+for cp_module in CIRCUITPYTHON_MODULES:
+    sys.modules.setdefault(cp_module, MagicMock())
+
+sys.modules["micropython"].const = lambda x: x

--- a/tests/test_solar_simulator.py
+++ b/tests/test_solar_simulator.py
@@ -1,0 +1,14 @@
+from solar_simulator import SolarSimulator
+
+
+def test_set_leds_updates_state() -> None:
+    # Arrange
+    sim = SolarSimulator()
+    # Act
+    sim.set_leds(v=1000, w=2000, c=3000, h=4000)
+    # Assert
+    assert sim.current_light_settings == {'v': 1000, 'w': 2000, 'c': 3000, 'h': 4000}
+    assert sim.mcp.channel_a.value == 1000
+    assert sim.mcp.channel_b.value == 2000
+    assert sim.mcp.channel_c.value == 3000
+    assert sim.hal.duty_cycle == 4000


### PR DESCRIPTION
## Changes

This chunk of work does a couple of things:

1) Makes it possible to run pytest (there was some missing configuration and circular dependency weirdness preventing this).
2) Adds the first (of hopefully many more) tests to the code base.
3) Adds CI to run our tests and lints.

## Noteworthy Callouts

- Using pytest in a circuitpython project will require us to do some hardware mocking.  I think we're all aware of this, but I think it's worth stating explicitly.  I have implemented the minimum required in `conftest.py` to get pytest to run the test I wrote successfully, given my current familiarity with pytest and with circuitpython (not as much as I'd like, but getting there 😝 ).

- The `calc_temp` refactor does not logically bundle into this chunk of work, but it was bugging me.  I chose to pull it into the SolarSimulator class and use `@staticmethod`.  It logically makes sense as part of the class but doesn't depend on or require using `self`.  And while it could have been moved into the `_read_thermistors` method as a nested function, I feel that this would obfuscate a meaningful function and needlessly make it harder to test.  Using `@staticmethod` seems the better middle ground between leaving it as-is and nesting it.